### PR TITLE
Fix creating images directory failing

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,13 +27,13 @@ let userManager = UserManager.getInstance();
 userManager.load();
 
 if(fs.existsSync('./wwwroot/images/icons') == false){
-    fs.mkdirSync('./wwwroot/images/icons');
+    fs.mkdirSync('./wwwroot/images/icons', {recursive: true});
 }
 if(fs.existsSync('./wwwroot/images/backgrounds') == false){
-    fs.mkdirSync('./wwwroot/images/backgrounds');
+    fs.mkdirSync('./wwwroot/images/backgrounds', {recursive: true});
 }
 if(fs.existsSync('./data/configs') == false){
-    fs.mkdirSync('./data/configs');
+    fs.mkdirSync('./data/configs', {recursive: true});
 }
 
 // express app


### PR DESCRIPTION
When running the node application after cloning the repo fails due to the images directory being missing in the wwwroot folder. This adds the recursive option to create parent directories when needed for the mkdir calls.

```
Error: ENOENT: no such file or directory, mkdir './wwwroot/images/icons'
    at Object.mkdirSync (node:fs:1336:3)
    at Object.<anonymous> (/Users/connor/Projects/Fenrus/app.js:30:8)
    at Module._compile (node:internal/modules/cjs/loader:1097:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1149:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: './wwwroot/images/icons'
}
```