### PR TITLE
Use alpine baseimage, optimise build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
-FROM node:16
+FROM alpine:3.15
 
 # Create app directory
 WORKDIR /app
 
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
-
-RUN npm install
-
-RUN npm ci --only=production
-
 # Bundle app source
 COPY . .
 
-RUN mkdir /data
+RUN \
+  apk -U --update --no-cache add --virtual=build-dependencies \
+    npm && \
+  apk -U --update --no-cache add \
+    nodejs && \    
+  rm -rf ./.git && \
+  npm install && \
+  npm ci --only=production && \
+  mkdir -p /data && \
+  apk del --purge \
+    build-dependencies
 
 EXPOSE 3000
 CMD [ "node", "app.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
   rm -rf ./.git && \
   npm install && \
   npm ci --only=production && \
-  mkdir -p /data && \
+  mkdir -p ./data && \
   apk del --purge \
     build-dependencies
 


### PR DESCRIPTION
The `node:16` baseimage you are using is over 900Mb, using the Alpine 3.15 image as a base and installing only the required node packages reduces the image size by 92%.