### PR TITLE
Add options to show radarr's 'missing' param by additional filters 

### DIFF
--- a/apps/Smart/Radarr/app.json
+++ b/apps/Smart/Radarr/app.json
@@ -7,6 +7,30 @@
       "Name": "API Key",
       "Id": "apikey",
       "Type": "string"
+    },
+	{
+      "Name": "Filter to apply to 'Missing' entries",
+      "Id": "filters",
+      "Type": "select",
+      "Options":
+      [
+        { 
+            "Label": "Show all missing",
+            "Value":"none"
+        },
+		{ 
+            "Label": "Missing only if entry is also marked as 'Monitored'",
+            "Value":"monitored"
+        },
+        { 
+            "Label": "Missing only if entry is also marked as 'Available'",
+            "Value":"available"
+        },
+        { 
+            "Label": "'Monitored' And 'Available'",
+            "Value":"both"
+        }
+      ]
     }
   ]
 }

--- a/apps/Smart/Radarr/code.js
+++ b/apps/Smart/Radarr/code.js
@@ -1,20 +1,32 @@
-﻿class Radarr
-{ 
-    getUrl(args, endpoint){
+﻿class Radarr {
+    getUrl(args, endpoint) {
         return `api/v3/${endpoint}?apikey=${args.properties['apikey']}`;
     }
-    
+
     async status(args) {
+        let filter = args.properties['filters'];
+
         let data = await args.fetch(this.getUrl(args, 'movie'));
-        let missing = data?.filter(x => x.hasFile == false)?.length ?? 0;
+        let filteredData = data?.filter((x, index, arr) => {
+            let validEntry = x.hasFile == false;
+            if (validEntry && (filter == 'both' || filter == 'available')) {
+                validEntry = x.isAvailable == true;
+            }
+            if (validEntry && (filter == 'both' || filter == 'monitored')) {
+                validEntry = x.monitored == true;
+            }
+            return validEntry;
+        })
+        let missingCount = filteredData?.length ?? 0;
+
         data = await args.fetch(this.getUrl(args, 'queue'));
         let queue = data?.records?.length ?? 0;
         return args.liveStats([
-            ['Missing', missing],
+            ['Missing', missingCount],
             ['Queue', queue]
         ]);
     }
-    
+
     async test(args) {
         let data = await args.fetch(this.getUrl(args, 'queue'));
         return isNaN(data?.records?.length) === false;


### PR DESCRIPTION
Allow missing param to only show missing if it is actually being monitored (this is default functionality for sonarr api) 

![image](https://user-images.githubusercontent.com/77850077/156940618-1fa6d0e7-1fdb-487c-b51f-408fd8d484ac.png)
