### PR TITLE
Search: Additional checks for full url and domain name with path

### DIFF
--- a/views/partials/search.ejs
+++ b/views/partials/search.ejs
@@ -59,8 +59,18 @@
                     return;
                 }
                 if(/^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/.test(searchText)){
-                    // donamename 
+                    // domainname 
                     window.location = 'http://' + searchText;
+                    return;
+                }
+                if(/^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9\-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})(\/.*)$/.test(searchText)){
+                    // domainname with path 
+                    window.location = 'http://' + searchText;
+                    return;
+                }
+                if(/^(http:\/\/|https:\/\/).*$/.test(searchText)){
+                    // full url
+                    window.location = searchText;
                     return;
                 }
 


### PR DESCRIPTION
Added two more checks for the search field.

1. domain name with path, for example "github.com/revenz/Fenrus".
2. full URLs, for example "https://github.com/revenz/Fenrus".

These inputs should not be forwarded to a search engine, but opened directly.

Use case:
Among other things, I use Fenrus in the Safari browser on the Mac. Unfortunately, the default search engine cannot be freely set in the browser. That's why I use the dashboard as a "new tab page" and thus the search field for URL entries, as well as for searches (like the address bar of the browser), to bypass this restriction of Safari.