### PR TITLE
Update README.md to fix PORT env variable name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ revenz/fenrus:latest
 
 Note: You can customise the port used by using the environmental variable "Port"
 ```
--e Port=1234
+-e PORT=1234
 ```
 
 ```


### PR DESCRIPTION
When environment variable is defined using "Port" (at least using Docker Compose) it doesn't make any difference since the actual variable name is "PORT". This commit gets rid of the confusion.