### PR TITLE
SSO: fallback to preferred_username when name not provided

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -403,6 +403,9 @@ public class HomeController : BaseController
         string username = User?.Identity?.Name ?? string.Empty;
         if (string.IsNullOrEmpty(username))
             username = User.Claims.FirstOrDefault(x => x.Type == "name")?.Value ?? string.Empty;
+
+        if (string.IsNullOrEmpty(username))
+            username = User.Claims.FirstOrDefault(x => x.Type == "preferred_username")?.Value ?? string.Empty;
         
         if (string.IsNullOrEmpty(username))
             return ReturnUnauthorized("No username returned from OAuth");


### PR DESCRIPTION
When using Fenrus with providers that do not supply a "name" claim as a part of the UserInfo response, fall back to the "preferred_username" claim.