### PR TITLE
Prevent "undefined" label into tiles view (e.g. for Plex app)

### DIFF
--- a/wwwroot/js/smartapp.js
+++ b/wwwroot/js/smartapp.js
@@ -281,7 +281,9 @@ class SmartApp
         else {
             this.setItemClass(eleItem, 'db-basic');
         }
-        ele.innerHTML = content;
+        if (content !== 'undefined') {
+            ele.innerHTML = content;
+        }
     }
 
     initialCarouselContent(content){


### PR DESCRIPTION
In latest development version I noticed that, in some apps, in tiles view, there is the "undefined" label.

As you can see, the problem happens in Plex app:
![image](https://github.com/user-attachments/assets/a87e9636-db62-44bf-be7d-c05522fc5907)

I found a missing check of "content" variable into smartapp.js file, so I changed and tested the change.